### PR TITLE
Save raw segmentation masks as PNG & clean up unused code

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -123,6 +123,8 @@ def inference(params: argparse.Namespace) -> None:
     # Process each file
     for file_path in tqdm(files_to_process, desc="Processing images"):
         filename = os.path.basename(file_path)
+        root_ext_pair = os.path.splitext(filename)
+        save_raw_path = os.path.join(output_path, root_ext_pair[0] + "_raw.png")
         save_path = os.path.join(output_path, filename)
 
         try:
@@ -144,6 +146,9 @@ def inference(params: argparse.Namespace) -> None:
 
             # Resize mask back to original image resolution
             restored_mask = mask_pil.resize(original_size, resample=Image.NEAREST)
+
+            # Save the raw mask
+            mask_pil.save(save_raw_path)
 
             # Convert back to numpy array
             predicted_mask = np.array(restored_mask)

--- a/onnx_inference.py
+++ b/onnx_inference.py
@@ -117,6 +117,8 @@ def inference_onnx(params: argparse.Namespace) -> None:
     # Process each file
     for file_path in tqdm(files_to_process, desc="Processing images"):
         filename = os.path.basename(file_path)
+        root_ext_pair = os.path.splitext(filename)
+        save_raw_path = os.path.join(output_path, root_ext_pair[0] + "_raw.png")
         save_path = os.path.join(output_path, filename)
         
         try:
@@ -144,6 +146,9 @@ def inference_onnx(params: argparse.Namespace) -> None:
             # Resize mask back to original image resolution
             restored_mask = mask_pil.resize(original_size, resample=Image.NEAREST)
             
+            # Save the raw mask
+            mask_pil.save(save_raw_path)
+
             # Convert back to numpy array
             predicted_mask = np.array(restored_mask)
             

--- a/utils/common.py
+++ b/utils/common.py
@@ -70,7 +70,6 @@ def vis_parsing_maps(image, segmentation_mask, save_image=False, save_path="resu
 
     # Save the result if required
     if save_image:
-        cv2.imwrite(save_path, segmentation_mask)
         cv2.imwrite(save_path, blended_image, [int(cv2.IMWRITE_JPEG_QUALITY), 100])
 
     return blended_image


### PR DESCRIPTION
This pull request exports the raw segmentation mask, which contains integer class IDs, as a .png file during inference. It also removes an unused line in `vis_parsing_maps()` that was likely left in by mistake.